### PR TITLE
feat: GetAllメソッドの実装とデバッグ用メソッドの追加 (#21)

### DIFF
--- a/week02/ToDoListApp/Program.cs
+++ b/week02/ToDoListApp/Program.cs
@@ -4,10 +4,14 @@ using ToDoListApp.Views;
 
 namespace ToDoListApp;
 
-class Program
-{
-    static void Main()
-    {
+class Program {
+    static void Main() {
         // デバッグエリア
+
+        var service = new TodoService();
+        service.AddTestDataForGetAll();
+        foreach (var task in service.GetAll()) {
+            Console.WriteLine($"{task.Id}: {task.Title} - {task.IsCompleted}");
+        }
     }
 }

--- a/week02/ToDoListApp/Services/TodoService.cs
+++ b/week02/ToDoListApp/Services/TodoService.cs
@@ -24,6 +24,22 @@ public class TodoService
         // 保持しているリストをコピーして返す
         return new List<TodoItem>(tasks);
     }
+    // GetAllメソッドデバッグ用のテストデータ追加メソッド
+    public void AddTestDataForGetAll()
+    {
+        tasks.Add(new TodoItem {
+            Id = nextId++,
+            Title = "kazuya",
+            IsCompleted = false,
+        });
+        tasks.Add(new TodoItem {
+            Id = nextId++,
+            Title = "taro",
+            IsCompleted = false,
+        });
+
+    }
+
     public bool Complete(int id)
     {
         return false;

--- a/week02/log.md
+++ b/week02/log.md
@@ -21,3 +21,28 @@
 - Day5,6共にブランチを複数作成してその時どのような作業をしていたか履歴を残すのを失念していた。
   - Day6途中で思い出したため、その地点からサブブランチを切って作業を勧めることとする
   - 対策として、その日の作業が始まる前にブランチ構成を考える時間を設ける。
+
+## Day 6: TodoServiceの`GetAll`メソッド実装&ブランチ履歴整理ログ
+### 概要
+- ブランチ切り替えの際に色々起きて混乱したのでログに残す
+
+### ログ
+### 作業内容
+- `TodoService.cs`に`GetAll()`メソッドを実装（タスク一覧の取得処理）
+- `AddTestDataGorGetAll()`メソッドを追加し、テスト用ダミーデータを投入
+- `Program.cs`で`GetAll()`の動作確認用ループを追加
+
+### Git操作履歴整理
+- `feature/say6-todolist-implementation`ブランチ上で進んでいたため、**rebaseを用いて履歴整理**
+- `git stash` -> `git checkout feature/day6-method-getall` -> `git stash pop`で作業を移動
+- コンフリクト発生個所（Program.cs）を手動解決し、`git rebase --continue`
+- rebase後のブランチ状態をリモートに反映するため、以下を実行:
+```bash
+git push --force-with-lease --set-upstream origin feature/day6-method-getall
+```
+
+### 反省点
+- **rebase前に意図するブランチで作業開始しておくことが重要**
+- 今後は作業開始前に`README.md`にその日のブランチ構成と予定を明記しておく
+- rebase後にpushする時は、`--force-with-lease`を使うことで安全に上書きできると学んだ。
+- **注意点として、チームで作業している際は、--force や --force-with-lease による push が他人の作業を上書き・削除してしまう可能性があるため、慎重に使う必要がある**


### PR DESCRIPTION
## 概要
`TodoService`クラスに、タスク一覧を取得する`GetAll()`メソッドを実装しました。  
加えて、デバッグ用途で初期データを追加する`AddTestDataForGetAll()`メソッドも実装しています。

## 主な変更点
- `Services/TodoService.cs` に `GetAll()` を実装
- 同クラスに `AddTestDataForGetAll()` を追加
- `Program.cs` にて `GetAll()` の動作確認用コードを追加

## 補足
- 実装のブランチは `feature/day6-method-getall`。
- 作業完了後に、`feature/day6-todolist-implementation` にマージします。
- rebaseと強制pushを使用して履歴を整えています（詳細は `log.md` 参照）。
- 間違えてpr #22 を作成してしまいましたが、無視してください。
- このGetAllメソッド作成はIssueを作っていませんが、次のAddメソッドからは個別でIssueを切ります。

## 注意点
- `--force-with-lease` によるpushを使用しており、チーム開発での使用時は履歴の上書きリスクに注意が必要です。

## 対応Issue
Day6全体の作業を追うための親Issue: #21 